### PR TITLE
package: ship vimrc and enable number+relativenumber by default

### DIFF
--- a/configs/vim/vimrc
+++ b/configs/vim/vimrc
@@ -1,0 +1,5 @@
+" Swiss Army Knife default Vim settings
+" Show absolute and relative line numbers
+set number
+set relativenumber
+

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -56,7 +56,10 @@ RUN apt-get update && \
     chmod +x /usr/bin/yq && \
     mkdir -p /root/.kube
 
-ENV LOGLEVEL_TAG v0.1
+# Editor config: Vim defaults (issue #26)
+COPY configs/vim/vimrc /etc/vim/vimrc
+
+ENV LOGLEVEL_TAG=v0.1
 RUN curl -sfSL https://github.com/rancher/loglevel/releases/download/${LOGLEVEL_TAG}/loglevel-amd64-${LOGLEVEL_TAG}.tar.gz | tar xvzf - -C /usr/bin
 COPY swiss-army-knife /usr/bin/
 WORKDIR /root


### PR DESCRIPTION
This PR addresses #26 by:

- Adding `configs/vim/vimrc` with:
  - `set number`
  - `set relativenumber`
- Updating `package/Dockerfile` to COPY the vimrc into `/etc/vim/vimrc`.

Rationale: enables useful line numbers by default.