### PR TITLE
fix(#33): add sysstat (iostat) to image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
         ldap-utils \
         less \
         libpcap-dev \
+        sysstat \
         man \
         manpages-posix \
         mtr \


### PR DESCRIPTION
Install sysstat to provide iostat in the tools image.

Helps with disk I/O performance debugging.

Fixes #33